### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,18 +5,17 @@ homepage: https://foreverday.one
 repository: https://github.com/4ed1/dart_mixpanel
 issue_tracker: https://github.com/4ed1/dart_mixpanel/issues
 
-version: 0.0.1
+version: 0.0.2
 
 dependencies:
     flutter:
         sdk: flutter
     uuid: ^2.0.2
     shared_preferences: ^0.5.3
-    package_info: ^0.4.0
+    package_info: '>=0.4.0 <2.0.0'
     device_info: ^0.4.0
     http: ^0.12.0
     meta: ^1.1.6
 
 environment:
   sdk: ">=2.0.0 <3.0.0"
-


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).